### PR TITLE
Allow default Umpire root directory to be overriden from environment …

### DIFF
--- a/umpire/config.py
+++ b/umpire/config.py
@@ -1,6 +1,7 @@
 import os.path, socket
 
-default_umpire_root = os.path.join(os.path.expanduser("~"), ".umpire")
+umpire_root_prefix = os.getenv('UMPIRE_ROOT_DIR', os.path.expanduser("~"))
+default_umpire_root = os.path.join(umpire_root_prefix, ".umpire")
 default_host_id = socket.gethostname()
 
 


### PR DESCRIPTION
Sometimes caching Umpire content to the user's default home directory might be problematic due to low disk capacity. It would be nice to give the user the ability to override the default location where Umpire packages are cached.