### PR TITLE
Fix windows deploy with python 3 string.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,12 @@ from os import path
 #     long_description = f.read()
 
 setup(name='Umpire',
-      version='0.6.4',
+      version='0.6.5',
       description='Generic dependency resolver.',
       long_description='',
       long_description_content_type='text/markdown',
-      author='Matthew Corner',
-      author_email='mcorner@signiant.com',
+      author='Signiant SRE',
+      author_email='sre@signiant.com',
       url='https://www.signiant.com',
       packages=find_packages(),
       license='MIT',

--- a/umpire/deploy.py
+++ b/umpire/deploy.py
@@ -44,7 +44,7 @@ def islink_windows(path):
     if os.path.exists(path):
         if os.path.isdir(path):
             FILE_ATTRIBUTE_REPARSE_POINT = 0x0400
-            attributes = ctypes.windll.kernel32.GetFileAttributesW(unicode(path))
+            attributes = ctypes.windll.kernel32.GetFileAttributesW(str(path))
             return (attributes & FILE_ATTRIBUTE_REPARSE_POINT) > 0
         else:
             command = ['dir', path]


### PR DESCRIPTION
Unicode function is deprecated in python3.  Must have been missed in python3 conversion.  This will allow the windows based deploy to work.