### PR TITLE
Update configparser for 3.12.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from os import path
 #     long_description = f.read()
 
 setup(name='Umpire',
-      version='0.7.1',
+      version='0.8.0',
       description='Generic dependency resolver.',
       long_description='',
       long_description_content_type='text/markdown',

--- a/umpire/cache.py
+++ b/umpire/cache.py
@@ -44,7 +44,7 @@ def create_local_cache(local_path, remote_url):
         pass #Directories exist
 
     ## Start creating config
-    config = configparser.SafeConfigParser()
+    config = configparser.ConfigParser()
     config.add_section(CONFIG_REPO_SECTION_NAME)
 
     config.set(CONFIG_REPO_SECTION_NAME, "remote_url", remote_url)

--- a/umpire/umpire.py
+++ b/umpire/umpire.py
@@ -6,7 +6,7 @@ import logging.handlers
 import logging.config
 import argparse
 
-__version__ = "0.6.5"
+__version__ = "0.8.0"
 
 import sys,os
 


### PR DESCRIPTION
This will update config parser as SafeConfigParser is deprecated in favour of ConfigParser.  This is backward compatible for earlier python versions.  Tested in 3.11.1 and 3.12.4. Should solve issues with 3.12.x+