### PR TITLE
Remove not needed distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,8 @@
 from setuptools import setup, find_packages
-from distutils.core import setup
-
 from os import path
-# this_directory = path.abspath(path.dirname(__file__))
-# with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
-#     long_description = f.read()
 
 setup(name='Umpire',
-      version='0.8.1',
+      version='0.8.2',
       description='Generic dependency resolver.',
       long_description='',
       long_description_content_type='text/markdown',

--- a/umpire/deploy.py
+++ b/umpire/deploy.py
@@ -24,7 +24,6 @@ except NameError:
 
 
 import sys, os, json, time, traceback, shutil, logging
-from distutils import dir_util
 from maestro.core import module
 from maestro.tools import path
 from tqdm import tqdm
@@ -289,8 +288,6 @@ class DeploymentModule(module.AsyncModule):
                 path.symlink(entry, destination_file)
             elif os.path.isdir(entry):
                 logger.debug("Copying with tree copy")
-                # dir_util.copy_tree(entry, destination_file)
-                # shutil.copytree(entry, destination_file, dirs_exist_ok=True)
                 self.copy_dir_with_progress(entry, destination_file)
             else:
                 logger.debug("Copying with file copy")

--- a/umpire/umpire.py
+++ b/umpire/umpire.py
@@ -6,7 +6,7 @@ import logging.handlers
 import logging.config
 import argparse
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 import sys,os
 


### PR DESCRIPTION
This will remove distutils which is no longer included in python 3.12.  Umpire was no longer using it and was probably meant to be removed in a previous version and stuck around.